### PR TITLE
Configure For building gurt_godot on ma

### DIFF
--- a/protocol/gdextension/Cargo.toml
+++ b/protocol/gdextension/Cargo.toml
@@ -14,15 +14,13 @@ crate-type = ["cdylib"]
 [dependencies]
 gurtlib = { path = "../library" }
 
-godot = "0.1"
+godot = { version = "0.1", features = ["experimental-threads"] }
 
 tokio = { version = "1.0", features = ["rt"] }
 url = "2.5"
 serde_json = "1.0"
 
 [profile.release]
-opt-level = "z"
-lto = true
-codegen-units = 1
-panic = "abort"
-strip = true
+opt-level = 3
+lto = false   # or "thin"
+codegen-units = 16

--- a/protocol/gdextension/Cargo.toml
+++ b/protocol/gdextension/Cargo.toml
@@ -22,5 +22,7 @@ serde_json = "1.0"
 
 [profile.release]
 opt-level = 3
-lto = false   # or "thin"
+lto = false
 codegen-units = 16
+strip = true
+panic = "abort"

--- a/protocol/gdextension/build.sh
+++ b/protocol/gdextension/build.sh
@@ -33,7 +33,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  -t, --target TARGET      Build target (debug|release) [default: release]"
-            echo "  -p, --platform PLATFORM Target platform (windows|linux|macos|current)"
+            echo "  -p, --platform PLATFORM Target platform (windows|linux|macos|macos-intel|current)"
             echo "  -h, --help              Show this help message"
             echo ""
             exit 0
@@ -82,6 +82,10 @@ case $PLATFORM in
         LIB_NAME="libgurt_godot.so"
         ;;
     macos)
+        RUST_TARGET="aarch64-apple-darwin"
+        LIB_NAME="libgurt_godot.dylib"
+        ;;
+    macos-intel)
         RUST_TARGET="x86_64-apple-darwin"
         LIB_NAME="libgurt_godot.dylib"
         ;;


### PR DESCRIPTION
Original description:

Fixed support for compiling the gurt_godot gdextension on MacOS
Build.sh supports apple silicon and intel macs in this commit.
This pull request or commit should not effect any godot files like project.godot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added build support for macOS (Intel) in addition to Apple Silicon.
  - Automatically targets the correct macOS architecture during builds.

- Performance Improvements
  - Increased optimization level and parallel code generation for release builds to improve runtime performance.
  - Enabled experimental threading features for better responsiveness in supported environments.

- Chores
  - Updated build configurations to align platforms and output naming across macOS variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->